### PR TITLE
[feat] 공통 api response 생성

### DIFF
--- a/src/main/java/com/spotify/spotifyserver/common/SpotifyResponse.java
+++ b/src/main/java/com/spotify/spotifyserver/common/SpotifyResponse.java
@@ -1,0 +1,20 @@
+package com.spotify.spotifyserver.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SpotifyResponse<T> {
+
+    private final int status;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    public static <T>SpotifyResponse<T> success(SuccessCode successCode, T data) {
+        return new SpotifyResponse<>(successCode.getHttpStatus().value(), successCode.getMessage(), data);
+    }
+}

--- a/src/main/java/com/spotify/spotifyserver/common/SuccessCode.java
+++ b/src/main/java/com/spotify/spotifyserver/common/SuccessCode.java
@@ -1,0 +1,17 @@
+package com.spotify.spotifyserver.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+    /**
+     * 200 OK
+     */
+    GET_SUCCESS(HttpStatus.OK, "조회 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## Related Issue 📌
close #6 

## Description ✔️
- 공통 api response 생성
- 공통 response의 status, message에 값을 넣기 위한 SuccessCode 생성

## To Reviewers
사용예시 : 
기존 controller에서 return ResponseEntity.status(HttpStatus.Ok).body(memberService.findMembers());
도입후 return SpotifyResponse.success(SuccessCode.success, memberService.findMembers());
이런식으로 사용하시면 됩니다.

세미나 자료랑 비교하시면서 구현, 사용법 복습해보시면 좋을 것 같습니다~