### PR TITLE
[feat] 아티스트 상세 페이지 api 생성

### DIFF
--- a/src/main/java/com/spotify/spotifyserver/common/SpotifyResponse.java
+++ b/src/main/java/com/spotify/spotifyserver/common/SpotifyResponse.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Getter
 public class SpotifyResponse<T> {
 
     private final int status;

--- a/src/main/java/com/spotify/spotifyserver/controller/ArtistController.java
+++ b/src/main/java/com/spotify/spotifyserver/controller/ArtistController.java
@@ -4,11 +4,14 @@ import com.spotify.spotifyserver.common.SpotifyResponse;
 import com.spotify.spotifyserver.common.SuccessCode;
 import com.spotify.spotifyserver.entity.Artist;
 import com.spotify.spotifyserver.service.ArtistService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -23,5 +26,17 @@ public class ArtistController {
     public SpotifyResponse<List<Artist>> getPopularArtists() {
         return SpotifyResponse.success(SuccessCode.GET_SUCCESS, artistService.findPopularArtists());
     }
+
+    // 특정 아티스트의 정보를 반환하는 API
+    @GetMapping("/artists/{artistId}")
+    public ResponseEntity<?> getArtistById(@PathVariable Long artistId) {
+        Optional<Artist> artist = artistService.getArtistById(artistId);
+        if (artist.isPresent()) {
+            return ResponseEntity.ok(SpotifyResponse.success(SuccessCode.GET_SUCCESS, artist.get()));
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
 
 }

--- a/src/main/java/com/spotify/spotifyserver/controller/ArtistController.java
+++ b/src/main/java/com/spotify/spotifyserver/controller/ArtistController.java
@@ -2,6 +2,7 @@ package com.spotify.spotifyserver.controller;
 
 import com.spotify.spotifyserver.common.SpotifyResponse;
 import com.spotify.spotifyserver.common.SuccessCode;
+import com.spotify.spotifyserver.dto.ArtistGetResponse;
 import com.spotify.spotifyserver.entity.Artist;
 import com.spotify.spotifyserver.service.ArtistService;
 import org.springframework.http.ResponseEntity;
@@ -29,14 +30,7 @@ public class ArtistController {
 
     // 특정 아티스트의 정보를 반환하는 API
     @GetMapping("/artists/{artistId}")
-    public ResponseEntity<?> getArtistById(@PathVariable Long artistId) {
-        Optional<Artist> artist = artistService.getArtistById(artistId);
-        if (artist.isPresent()) {
-            return ResponseEntity.ok(SpotifyResponse.success(SuccessCode.GET_SUCCESS, artist.get()));
-        } else {
-            return ResponseEntity.notFound().build();
-        }
+    public SpotifyResponse<ArtistGetResponse> getArtist(@PathVariable final Long artistId) {
+        return SpotifyResponse.success(SuccessCode.GET_SUCCESS, artistService.getArtist(artistId));
     }
-
-
 }

--- a/src/main/java/com/spotify/spotifyserver/dto/ArtistGetResponse.java
+++ b/src/main/java/com/spotify/spotifyserver/dto/ArtistGetResponse.java
@@ -1,0 +1,11 @@
+package com.spotify.spotifyserver.dto;
+
+import com.spotify.spotifyserver.entity.Artist;
+
+import java.util.List;
+
+public record ArtistGetResponse(long id, String artistName, List<SongResponse> songs) {
+        public static ArtistGetResponse of(Artist artist, List<SongResponse> songs) {
+            return new ArtistGetResponse(artist.getId(), artist.getName(), songs);
+        }
+}

--- a/src/main/java/com/spotify/spotifyserver/dto/SongResponse.java
+++ b/src/main/java/com/spotify/spotifyserver/dto/SongResponse.java
@@ -1,0 +1,9 @@
+package com.spotify.spotifyserver.dto;
+
+import com.spotify.spotifyserver.entity.Song;
+
+public record SongResponse(long id, String title, long listenedCount) {
+    public static SongResponse of(Song song) {
+        return new SongResponse(song.getId(), song.getTitle(), song.getListenedCount());
+    }
+}

--- a/src/main/java/com/spotify/spotifyserver/entity/Artist.java
+++ b/src/main/java/com/spotify/spotifyserver/entity/Artist.java
@@ -5,6 +5,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,5 +22,8 @@ public class Artist {
 
     @Column(name = "like_count", nullable = false)
     private int likeCount;
+
+    @OneToMany(mappedBy = "artist")
+    private List<Song> songs = new ArrayList<>();
 
 }

--- a/src/main/java/com/spotify/spotifyserver/repository/ArtistRepository.java
+++ b/src/main/java/com/spotify/spotifyserver/repository/ArtistRepository.java
@@ -11,7 +11,6 @@ public interface ArtistRepository extends JpaRepository<Artist, Long> {
     @Query("SELECT a FROM Artist a ORDER BY a.likeCount DESC")
     List<Artist> findTopArtistsByLikeCountJPQL();
 
-    // 아티스트 ID로 아티스트 조회
-    Optional<Artist> findById(Long id);
-
+    @Query("SELECT a FROM Artist a JOIN FETCH a.songs WHERE a.id = :artistId")
+    Optional<Artist> findByIdWithArtistJPQL(Long artistId);
 }

--- a/src/main/java/com/spotify/spotifyserver/repository/ArtistRepository.java
+++ b/src/main/java/com/spotify/spotifyserver/repository/ArtistRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
     @Query("SELECT a FROM Artist a ORDER BY a.likeCount DESC")
     List<Artist> findTopArtistsByLikeCountJPQL();
+
+    // 아티스트 ID로 아티스트 조회
+    Optional<Artist> findById(Long id);
+
 }

--- a/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
+++ b/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
@@ -1,14 +1,17 @@
 package com.spotify.spotifyserver.service;
 
+import com.spotify.spotifyserver.dto.ArtistGetResponse;
+import com.spotify.spotifyserver.dto.SongResponse;
 import com.spotify.spotifyserver.entity.Artist;
 import com.spotify.spotifyserver.repository.ArtistRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class ArtistService {
+
     private final ArtistRepository artistRepository;
 
     public ArtistService(ArtistRepository artistRepository) {
@@ -19,8 +22,9 @@ public class ArtistService {
         return artistRepository.findTopArtistsByLikeCountJPQL();
     }
 
-    // ID로 아티스트 조회
-    public Optional<Artist> getArtistById(Long id) {
-        return artistRepository.findById(id);
+    public ArtistGetResponse getArtist(Long artistId) {
+        Artist artist = artistRepository.findByIdWithArtistJPQL(artistId).get();
+        List<SongResponse> songResponses = artist.getSongs().stream().map(SongResponse::of).collect(Collectors.toList());
+        return ArtistGetResponse.of(artist, songResponses);
     }
 }

--- a/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
+++ b/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
@@ -5,6 +5,7 @@ import com.spotify.spotifyserver.repository.ArtistRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ArtistService {
@@ -16,5 +17,10 @@ public class ArtistService {
 
     public List<Artist> findPopularArtists() {
         return artistRepository.findTopArtistsByLikeCountJPQL();
+    }
+
+    // ID로 아티스트 조회
+    public Optional<Artist> getArtistById(Long id) {
+        return artistRepository.findById(id);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
close #15 

## Description ✔️
1. ArtistRepository 수정
ArtistRepository에 특정 아티스트 ID로 아티스트를 조회하는 쿼리 메소드를 추가
``` 
// 아티스트 ID로 아티스트 조회
    Optional<Artist> findById(Long id);
``` 


2. ArtistService 수정
ArtistService에 findById 메소드를 추가하여 컨트롤러에서 요청된 아티스트 ID로 아티스트 정보를 조회할 수 있도록 함

```
// ID로 아티스트 조회
public Optional<Artist> getArtistById(Long id) {
        return artistRepository.findById(id);
    }
```


3. ArtistController 수정
ArtistController에 /artists/{artistId} 엔드포인트를 추가하여 특정 아티스트의 정보를 반환하는 API를 구현

```
// 특정 아티스트의 정보를 반환하는 API
    @GetMapping("/artists/{artistId}")
    public ResponseEntity<?> getArtistById(@PathVariable Long artistId) {
        Optional<Artist> artist = artistService.getArtistById(artistId);
        if (artist.isPresent()) {
            return ResponseEntity.ok(SpotifyResponse.success(SuccessCode.GET_SUCCESS, artist.get()));
        } else {
            return ResponseEntity.notFound().build();
        }
    }
```


4. 더미데이터 생성


5. postman 확인
http://localhost:8080/api/v1/artists/1
![image](https://github.com/NOW-SOPT-APP9-SPOTIFY/Spotify_Server/assets/130284467/39d6b2f2-21dd-4eba-8067-21abff8f3961)

## To Reviewers
