### PR TITLE
[fix] 인기 아티스트 api 변경

### DIFF
--- a/src/main/java/com/spotify/spotifyserver/common/SpotifyResponse.java
+++ b/src/main/java/com/spotify/spotifyserver/common/SpotifyResponse.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter

--- a/src/main/java/com/spotify/spotifyserver/controller/ArtistController.java
+++ b/src/main/java/com/spotify/spotifyserver/controller/ArtistController.java
@@ -2,8 +2,10 @@ package com.spotify.spotifyserver.controller;
 
 import com.spotify.spotifyserver.common.SpotifyResponse;
 import com.spotify.spotifyserver.common.SuccessCode;
+import com.spotify.spotifyserver.dto.ArtistDTO;
 import com.spotify.spotifyserver.entity.Artist;
 import com.spotify.spotifyserver.service.ArtistService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,15 +15,12 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1")
 public class ArtistController {
-    private final ArtistService artistService;
-
-    public ArtistController(ArtistService artistService) {
-        this.artistService = artistService;
-    }
+    @Autowired
+    private ArtistService artistService;
 
     @GetMapping("/artists/popular")
-    public SpotifyResponse<List<Artist>> getPopularArtists() {
-        return SpotifyResponse.success(SuccessCode.GET_SUCCESS, artistService.findPopularArtists());
+    public SpotifyResponse<List<ArtistDTO>> getPopularArtists() {
+        List<ArtistDTO> artists = artistService.findAllArtists();
+        return SpotifyResponse.success(SuccessCode.GET_SUCCESS, artists);
     }
-
 }

--- a/src/main/java/com/spotify/spotifyserver/dto/ArtistDTO.java
+++ b/src/main/java/com/spotify/spotifyserver/dto/ArtistDTO.java
@@ -1,0 +1,19 @@
+package com.spotify.spotifyserver.dto;
+
+import java.util.List;
+
+public class ArtistDTO {
+    private Long id;
+    private String artistName;
+
+    // 생성자, getter 및 setter
+    public ArtistDTO(Long id, String artistName) {
+        this.id = id;
+        this.artistName = artistName;
+    }
+
+    public Long getId() { return id; }
+    public String getArtistName() { return artistName; }
+    public void setId(Long id) { this.id = id; }
+    public void setArtistName(String artistName) { this.artistName = artistName; }
+}

--- a/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
+++ b/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
@@ -17,7 +17,9 @@ public class ArtistService {
     }
 
     public List<ArtistDTO> findAllArtists() {
-        return artistRepository.findAll().stream()
+        List<Artist> artists = artistRepository.findTopArtistsByLikeCountJPQL();
+
+        return artists.stream()
                 .map(artist -> new ArtistDTO(artist.getId(), artist.getName()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
+++ b/src/main/java/com/spotify/spotifyserver/service/ArtistService.java
@@ -1,10 +1,12 @@
 package com.spotify.spotifyserver.service;
 
+import com.spotify.spotifyserver.dto.ArtistDTO;
 import com.spotify.spotifyserver.entity.Artist;
 import com.spotify.spotifyserver.repository.ArtistRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ArtistService {
@@ -14,7 +16,9 @@ public class ArtistService {
         this.artistRepository = artistRepository;
     }
 
-    public List<Artist> findPopularArtists() {
-        return artistRepository.findTopArtistsByLikeCountJPQL();
+    public List<ArtistDTO> findAllArtists() {
+        return artistRepository.findAll().stream()
+                .map(artist -> new ArtistDTO(artist.getId(), artist.getName()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Related Issue 📌
close #17 

## Description ✔️
- DTO랑 연결해서 되게 변경..

1. DTO 클래스 정의
ArtistDTO 클래스 생성

``` 
public class ArtistDTO {
    private Long id;
    private String artistName;

    // 생성자, getter 및 setter
    public ArtistDTO(Long id, String artistName) {
        this.id = id;
        this.artistName = artistName;
    }

    public Long getId() { return id; }
    public String getArtistName() { return artistName; }
    public void setId(Long id) { this.id = id; }
    public void setArtistName(String artistName) { this.artistName = artistName; }
}
``` 

2. 서비스 레이어 수정
``` 
@Service
public class ArtistService {
    @Autowired
    private ArtistRepository artistRepository;

    public List<ArtistDTO> findAllArtists() {
        List<Artist> artists = artistRepository.findTopArtistsByLikeCountJPQL();
        return artists.stream()
                .map(artist -> new ArtistDTO(artist.getId(), artist.getName()))
                .collect(Collectors.toList());

    }
}
``` 

3. 컨트롤러 수정

``` 
@RestController
@RequestMapping("/api/v1")
public class ArtistController {
    @Autowired
    private ArtistService artistService;

    @GetMapping("/artists/popular")
    public SpotifyResponse<List<ArtistDTO>> getPopularArtists() {
        List<ArtistDTO> artists = artistService.findAllArtists();
        return SpotifyResponse.success(SuccessCode.GET_SUCCESS, artists);
    }
}
``` 

4. 더미 데이터 생성
<img width="477" alt="image" src="https://github.com/NOW-SOPT-APP9-SPOTIFY/Spotify_Server/assets/130284467/c96f0484-6295-45f5-bc07-b9ff67e04a9d">


5. postman 확인
<img width="182" alt="image" src="https://github.com/NOW-SOPT-APP9-SPOTIFY/Spotify_Server/assets/130284467/351f6a8e-b34a-4229-ac71-134896cf81d9">



## To Reviewers
